### PR TITLE
Robotic Voicebox

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -562,6 +562,17 @@
 	build_path = /obj/item/organ/lungs/cybernetic/upgraded
 	category = list("Misc", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	
+/datum/design/robo_tongue
+	name = "Robotic Voicebox"
+	desc = "A voice synthesizer that can interface with organic lifeforms."
+	id = "robo-tongue"
+	build_type = PROTOLATHE | MECHFAB
+	construction_time = 35
+	materials = list(/datum/material/iron = 600, /datum/material/glass = 250)
+	build_path = /obj/item/organ/tongue/robot
+	category = list("Misc", "Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
 /////////////////////
 ///Surgery Designs///


### PR DESCRIPTION
## About The Pull Request

Adds robotic voiceboxes as printable items in the Medical lathe and exofab. 

## Why It's Good For The Game

For all those roboticists and other robotics-loving crewmembers to finally be able to talk in `robot voice` like they always wanted to but had to get admins to spawn this item for them instead.

## Changelog
:cl:
add: Added printable robotic voiceboxes
/:cl:
